### PR TITLE
feat: Added small changes to the InformationBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,15 +783,25 @@ Key Methods:
 - `add_activity(activity: Dict)`
 - `get_memory(memory_type: str, time_range: Tuple[int, int]): List`
 
+#### BoardMessage
+
+Tha BoardMessage class is a wrapper around ACLMessage for ease of use in the InformationBoard.
+
+Key Attributes:
+
+- `message`: ACLMessage
+- `date_posted`: datetime
+- `title`: Optional[str]
+
 #### InformationBoard
 The InformationBoard class serves as a centralized repository for economic news and statistics.
 
 Key Attributes:
-- `posts`: List[ACLMessage]
+- `posts`: List[BoardMessage]
 
 Key Methods:
-- `add_post(post: ACLMessage)`
-- `get_relevant_posts(agent: Agent): List[ACLMessage]`
+- `add_post(post: BoardMessage)`
+- `get_relevant_posts(relevant_topics: List[str]): List[BoardMessage]`
 - `retrieve_information(): List[str]`
 
 #### SocialNetwork


### PR DESCRIPTION
Proposed changes:

1. Addition of a `BoardMessage` class to add a few fields to the `ACLMessage` and abstract it for ease of implementation + modifying and extension
2. Changing the main argument of `get_relevant_posts` function from `agent: Agent` to `relevant_topics: List[str]`. This seemed quite straightforward to me: using embedding based retrieval + (optionally) reranking the posts given the topic(s) is a solid way of retrieving relevant posts, unless there's a requirement I'm missing that we need just the agent field for this function.

Question before the PR is merged: **Should the function and return contents of the function `retrieve_information` be discussed right now or after we have some parts of the simulation set up?**